### PR TITLE
Fix typo: BoxedMorph should be BoxMorph

### DIFF
--- a/Tools-Finder.pck.st
+++ b/Tools-Finder.pck.st
@@ -47,7 +47,7 @@ FinderSearchTextModelMorph class
 	instanceVariableNames: ''!
 
 !classDefinition: #FinderSearchBar category: #'Tools-Finder-UI'!
-BoxedMorph subclass: #FinderSearchBar
+BoxMorph subclass: #FinderSearchBar
 	instanceVariableNames: 'layoutMorph searchBox changeHandler keyPressedHandler dateAndTimeOfLastKeyStroke timeToWaitBeforeNotifyingChanges'
 	classVariableNames: ''
 	poolDictionaries: ''


### PR DESCRIPTION
The class BoxedMorph doesn't exist. The consequence is that FinderSearchBar, once compiled subclassifies from ProtoObject.